### PR TITLE
Interpolate description directly

### DIFF
--- a/generate-modulemd.py
+++ b/generate-modulemd.py
@@ -266,9 +266,7 @@ def work(sack):
     data:
         summary: {{ config.get_config('summary') }}
         description: >-
-            {% for line in config.get_config('description') %}
-            {{ line }}
-            {% endfor %}
+    {{ config.get_config('description').rstrip() }}
         license:
             module:
                 - MIT


### PR DESCRIPTION
If the description in the config is at the natural indent level, there's no need to force it to a list - it can be output directly.
This:
```
    "description": """\
        Scala is a general purpose programming language designed to express
        common programming patterns in a concise, elegant, and type-safe way.
        It smoothly integrates features of object-oriented and functional
        languages. It is also fully interoperable with Java.
    """,
```

Gets output as this:
```
    description: >-
        Scala is a general purpose programming language designed to express
        common programming patterns in a concise, elegant, and type-safe way.
        It smoothly integrates features of object-oriented and functional
        languages. It is also fully interoperable with Java.
```

IMHO, this would make writing new modules a bit easier, but it requires changing the current configs.